### PR TITLE
Add link to the GitHub repo.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ pub fn get_cli_matches<'a>() -> ArgMatches<'static> {
     App::new("ynot")
         .version("0.1")
         .author("m")
-        .about("readme")
+        .about("See https://github.com/grapegrip/wool")
         .arg(
             Arg::with_name("infile")
                 .help("Sets the input file to use")


### PR DESCRIPTION
I installed wool, started playing with it, and got interrupted.

Several days later, I returned to my clone, but forgot its origins.  `wool -h` wasn't helpful to find more formal docs.

If this PR is merged, `wool -h` will now echo `See https://github.com/grapegrip/wool` near the top of the output.

Like this.

```
$ ./target/debug/wool -h
ynot 0.1
m
See https://github.com/grapegrip/wool

USAGE:
    wool [FLAGS] <infile> [outfile]

FLAGS:
    -b, --browser             Open in browser
    -e, --export              Export html
    -h, --help                Prints help information
    -s, --highlight           Syntax highlighting
    -k, --katex               Include katex in rendering
    -n, --no-preview-frame    Don't render the preview frame
    -V, --version             Prints version information

ARGS:
    <infile>     Sets the input file to use
    <outfile>    Sets the output file to use
```