### PR TITLE
Update Rust to the 2024 edition, and various fixes arising as suggested by the newer tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wool"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Your Name Here <your_email@youremail.com>"]
 edition = "2024"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wool"
 version = "0.1.2"
 authors = ["Your Name Here <your_email@youremail.com>"]
-edition = "2018"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use clap::{App, Arg, ArgMatches};
 
-pub fn get_cli_matches<'a>() -> ArgMatches<'static> {
+pub fn get_cli_matches() -> ArgMatches<'static> {
     App::new("ynot")
         .version("0.1")
         .author("m")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use comrak::{markdown_to_html, ComrakOptions};
-mod template;
+pub mod template;
 
 pub fn github_markdown_to_html(md: String, filename: String) -> String {
     let mut contents = String::from("");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,16 +16,17 @@ pub fn github_markdown_to_html(md: String, filename: String) -> String {
 }
 
 fn set_opts() -> ComrakOptions {
-    let mut options = ComrakOptions::default();
-    options.unsafe_ = true;
-    options.github_pre_lang = true;
-    options.ext_table = true;
-    options.ext_tagfilter = true;
-    options.ext_strikethrough = true;
-    options.ext_footnotes = true;
-    options.ext_superscript = true;
-    options.ext_autolink = true;
-    options.ext_tasklist = true;
-    options.ext_description_lists = true;
-    options
+    comrak::ComrakOptions {
+        unsafe_: true,
+        github_pre_lang: true,
+        ext_table: true,
+        ext_tagfilter: true,
+        ext_strikethrough: true,
+        ext_footnotes: true,
+        ext_superscript: true,
+        ext_autolink: true,
+        ext_tasklist: true,
+        ext_description_lists: true,
+        ..Default::default()
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ async fn router(updaters: SenderListPtr, req: Request<Body> ) -> Result<Response
           
 
             let root = Path::new("");
-             let result = resolve_path(&root, &req.uri().path()).await.unwrap();
+             let result = resolve_path(&root, req.uri().path()).await.unwrap();
              
              match result {
         ResolveResult::MethodNotMatched => return Ok(method_not_allowed()),
@@ -198,7 +198,7 @@ fn spawn_watcher(updaters: SenderListPtr) -> notify::Result<RecommendedWatcher> 
     // it forks of a mio event loop in the background and then calls the provided closure
     // with the yielded events
     let cwd = env::current_dir().unwrap(); 
-    let md_file_name = cwd.join(&(matches.value_of("infile").unwrap())).to_owned(); 
+    let md_file_name = cwd.join(matches.value_of("infile").unwrap());
     let mut file_event_watcher: RecommendedWatcher =
         Watcher::new_immediate(move |event: notify::Result<Event>| {
             let event = match event {
@@ -343,17 +343,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 
 fn set_opts() -> ComrakOptions {
-    let mut options = ComrakOptions::default();
-    options.unsafe_ = true;
-    options.github_pre_lang = true;
-    options.ext_table = true;
-    options.ext_tagfilter = true;
-    options.ext_strikethrough = true;
-    options.ext_footnotes = true;
-    options.ext_superscript = true;
-    options.ext_autolink = true;
-    options.ext_tasklist = true;
-    options.ext_description_lists = true;
-    options
+    ComrakOptions {
+        unsafe_ : true,
+        github_pre_lang : true,
+        ext_table : true,
+        ext_tagfilter : true,
+        ext_strikethrough : true,
+        ext_footnotes : true,
+        ext_superscript : true,
+        ext_autolink : true,
+        ext_tasklist : true,
+        ext_description_lists : true,
+        ..Default::default()
+    }
+
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ async fn router(updaters: SenderListPtr, req: Request<Body> ) -> Result<Response
           
 
             let root = Path::new("");
-             let result = hyper_staticfile::resolve_path(&root, &req.uri().path()).await.unwrap();
+             let result = resolve_path(&root, &req.uri().path()).await.unwrap();
              
              match result {
         ResolveResult::MethodNotMatched => return Ok(method_not_allowed()),
@@ -147,7 +147,7 @@ async fn router(updaters: SenderListPtr, req: Request<Body> ) -> Result<Response
         _ => (),
     };
              
-                Ok(hyper_staticfile::ResponseBuilder::new().request(&req).build(result).unwrap())
+                Ok(ResponseBuilder::new().request(&req).build(result).unwrap())
 
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,43 +126,7 @@ async fn md_file() -> Result<Response<Body>, hyper::Error> {
         </script> "#);
     }
     
-    
     Ok(response.body(Body::from(contents)).expect("invalid response builder"))
-}
-
-// Will only serve files relative to the md file
-async fn static_file(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
-    let response = Response::builder();
-    let cwd = std::env::current_dir().expect("no working dir");
-    if req.uri().path().len() > 1 {
-        let mut fullpath = cwd.clone();
-        // path() contains preceeding forward slash: /some/web/page
-                    println!("{:?}, {:?}", fullpath, &req.uri());
-        fullpath.push(&req.uri().path()[1..]);
-        // canonicalize returns Err if path does not exist.
-        if let Ok(fullpath) = fullpath.canonicalize() {
-            if fullpath.starts_with(&cwd) {
-                if let Ok(_file) = File::open(&fullpath).await {
-                    let buf = String::new();
-                    //if file.read_to_string(&mut buf).await.is_ok() {
-                        return Ok(response
-                            .body(Body::from(buf))
-                            .expect("invalid response builder"));
-                    //}
-                }
-            }
-        }
-    }
-   
-    info!("{} not found", req.uri());
-    // not found  
-    //return Ok(Response::default())
-   // return Ok(response.body(Body::from(req.uri())).expect("invalid response builder"))
-        
-    return Ok(response
-        .body(Body::from("foo"))
-        .expect("invalid response builder"))
-        
 }
 
 async fn router(updaters: SenderListPtr, req: Request<Body> ) -> Result<Response<Body>, hyper::error::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,12 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 // use tokio_io::AsyncReadExt;
 use tokio_sync::oneshot::{self, Sender};
-use tokio_io::*;
 use tokio::io::AsyncReadExt;
+
+use wool::template;
 
 mod cli;
 mod prism;
-mod template;
 mod openurl;
 mod katex;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use comrak::{markdown_to_html, ComrakOptions};
 use std::fs;
 use std::fs::File as Sync_File;
 use std::io::Write;
-use std::io::Error;
 use url::Url;
 use log::{info, debug, error};
 use std::path::Path;
@@ -24,11 +23,7 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tokio_fs::File;
 // use tokio_io::AsyncReadExt;
 use tokio_sync::oneshot::{self, Sender};
-use tokio_sync::*;
-use tokio::*;
-use tokio_fs::*;
 use tokio_io::*;
-use tokio_sync::*;
 use tokio::io::AsyncReadExt;
 
 mod cli;
@@ -40,7 +35,7 @@ mod katex;
 type SenderListPtr = Arc<Mutex<Vec<Sender<()>>>>;
 
 async fn update(updaters: SenderListPtr) -> Result<Response<Body>, hyper::Error> {
-    let mut response = Response::builder();
+    let response = Response::builder();
     /*
     response.header("Cache-Control", "no-cache, no-store, must-revalidate");
     response.header("Pragma", "no-cache");
@@ -61,7 +56,7 @@ async fn update(updaters: SenderListPtr) -> Result<Response<Body>, hyper::Error>
 }
 
 async fn md_file() -> Result<Response<Body>, hyper::Error> {
-    let mut response = Response::builder();
+    let response = Response::builder();
     // response.header("Content-type", "text/html");
     
     let matches = cli::get_cli_matches();
@@ -137,7 +132,7 @@ async fn md_file() -> Result<Response<Body>, hyper::Error> {
 
 // Will only serve files relative to the md file
 async fn static_file(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
-    let mut response = Response::builder();
+    let response = Response::builder();
     let cwd = std::env::current_dir().expect("no working dir");
     if req.uri().path().len() > 1 {
         let mut fullpath = cwd.clone();
@@ -147,8 +142,8 @@ async fn static_file(req: Request<Body>) -> Result<Response<Body>, hyper::Error>
         // canonicalize returns Err if path does not exist.
         if let Ok(fullpath) = fullpath.canonicalize() {
             if fullpath.starts_with(&cwd) {
-                if let Ok(mut file) = File::open(&fullpath).await {
-                    let mut buf = String::new();
+                if let Ok(_file) = File::open(&fullpath).await {
+                    let buf = String::new();
                     //if file.read_to_string(&mut buf).await.is_ok() {
                         return Ok(response
                             .body(Body::from(buf))
@@ -281,7 +276,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let markdown = markdown_to_html(&contents, &options);
     let highlight = matches.is_present("highlight");
     let browser = matches.is_present("browser");
-    let latex = matches.is_present("katex");
+    let _latex = matches.is_present("katex");
 
     if matches.is_present("export-flag") {
         let infile = matches.value_of("infile").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::fs::File as Sync_File;
 use std::io::Write;
 use url::Url;
-use log::{info, debug, error};
+use log::{debug, error};
 use std::path::Path;
 use hyper::header;
 
@@ -20,7 +20,6 @@ use hyper::{Body, Request, Response, Server, StatusCode};
 use hyper_staticfile::*;
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
-use tokio_fs::File;
 // use tokio_io::AsyncReadExt;
 use tokio_sync::oneshot::{self, Sender};
 use tokio_io::*;

--- a/src/openurl.rs
+++ b/src/openurl.rs
@@ -2,37 +2,6 @@
 
 use url::Url;
 
-// Convenience method to open URLs
-pub trait UrlOpen {
-    fn open(&self);
-}
-
-impl UrlOpen for Url {
-    fn open(&self) {
-        open(self);
-    }
-}
-
-/*
-#[cfg(target_os = "windows")]
-pub fn open(url: &Url) {
-    extern crate shell32;
-    extern crate winapi;
-
-    use std::ffi::CString;
-    use std::ptr;
-
-    unsafe {
-        shell32::ShellExecuteA(ptr::null_mut(),
-                               CString::new("open").unwrap().as_ptr(),
-                               CString::new(url.to_string().replace("\n", "%0A")).unwrap().as_ptr(),
-                               ptr::null(),
-                               ptr::null(),
-                               winapi::SW_SHOWNORMAL);
-    }
-}
-*/
-
 #[cfg(target_os = "macos")]
 pub fn open(url: &Url) {
     let _ = std::process::Command::new("open").arg(url.to_string()).output();

--- a/src/template.rs
+++ b/src/template.rs
@@ -89,7 +89,6 @@ container new-discussion-timeline experiment-repo-nav\"> -->
 }
 
 pub fn format_boilerplate_no_preview(_filename: &str) -> String {
-    format!(
 "
 <!DOCTYPE html>
 <html>
@@ -163,7 +162,7 @@ pub fn format_boilerplate_no_preview(_filename: &str) -> String {
     </style>
   <body>
     <article class=\"markdown-body\"> 
- ")
+ ".to_string()
 }
 
 /*


### PR DESCRIPTION
If merged, this PR will apply the following changes to `wool`

* Upgrade Rust to the 2024 edition
* Fix warnings arising from the 2024 edition of rust
* Apply various lints suggested by the latest versions of cargo-clippy and rust analyzer
* Bump the version of `wool` to the next minor increment, version `0.2.0`